### PR TITLE
Potential fix for code scanning alert no. 108: Clear-text logging of sensitive information

### DIFF
--- a/pkg/util/proxyutil/reverse_proxy.go
+++ b/pkg/util/proxyutil/reverse_proxy.go
@@ -149,8 +149,9 @@ type logWrapper struct {
 
 // Write writes log messages as bytes from proxy.
 func (lw *logWrapper) Write(p []byte) (n int, err error) {
-	withoutNewline := strings.TrimSuffix(string(p), "\n")
-	lw.logger.Error("Proxy request error", "error", withoutNewline)
+	// Redact the content to avoid logging sensitive data
+	redactedMessage := "[REDACTED]"
+	lw.logger.Error("Proxy request error", "error", redactedMessage)
 	return len(p), nil
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/dsp-testing/alona-grafana-internal/security/code-scanning/108](https://github.com/dsp-testing/alona-grafana-internal/security/code-scanning/108)

To address the issue, we need to ensure that sensitive data is not logged in plaintext. The best approach is to sanitize or obfuscate the data before logging it. For example, we can hash the data or replace sensitive parts with placeholders. Alternatively, we can avoid logging the data entirely if it is not necessary for debugging or monitoring purposes.

In this case, we will modify the `Write` method in the `logWrapper` struct to obfuscate the content of `p` before logging it. A simple approach is to replace the content with a fixed message like "[REDACTED]" or hash the content using a cryptographic hash function (e.g., SHA-256). This ensures that sensitive data is not exposed in the logs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
